### PR TITLE
Added more information about load address and boot command

### DIFF
--- a/Hardware/BeagleBoard.md
+++ b/Hardware/BeagleBoard.md
@@ -118,26 +118,33 @@ Some quick useful commands:
 Which after a few minutes should give you:
 
 Now, the ELF image we
-boot into is the `sel4test-image-arm-omap3` file. Pull out the SD card, put it
-into the SD card reader and plug into your computer, then copy that file
-into the boot sector, then sync and remove, then plug the SD card back
-into the BeagleBoard.
-
-Reset the BeagleBoard by pressing the `S2` (reset) button.
+boot into is the `sel4test-driver-image-arm-omap3` file. 
+Copy that file onto the sdcard (the boot loader will be able to load images into RAM from a FAT image: there is no need to do an image copy). If your SD card is not formatted, just format it using FAT32.
+Plug the SD card back into the BeagleBoard and reset the board by pressing the `S2` (reset) button.
 
 ### To run the image:
 ``` 
 mmc init
 mmcinfo
-fatload mmc 0 ${loadaddr} sel4test-image-arm
+fatload mmc 0 ${loadaddr} sel4test-driver-image-arm-omap3
 bootelf ${loadaddr}
 ```
 where loadaddr
 is some address, in this example defined as an environment variable.
+
+Note: by default, the image produced is relocated to run at address 0x82000000. If you want to change the address, you need to modify the file `projects/tools/elfloader-tool/gen_boot_image.sh` (look for the omap3 case). For the Beaglebone Black Rev A5, RAM is from address 0x80000000 - 0x9FFFFFFF. 
+
+Depending on the uBoot version present on the Beaglebone, the `bootelf` command might not be present. You can use the `go` command instead. I.e.:
+```
+mmc init
+mmcinfo
+fatload mmc 0 0x82000000 sel4test-driver-image-arm-omap3
+go 0x82000000
+```
+
 After this you should start seeing output from seL4test.
 
-You can use:
-
+Tip: if you don't remember the name of the images on your SD card, you can use:
 ```
 fatls mmc 0
 ```


### PR DESCRIPTION
Update name of the generated image, clarified (and updated) the instructions to copy the image and the command to boot from sd card.
Added a note about the load address to use and how to change it.
Added a note to cover situations where the bootelf command is not available