### PR TITLE
dtc package fix

### DIFF
--- a/HostDependencies.md
+++ b/HostDependencies.md
@@ -33,7 +33,7 @@ Additional base dependencies for building seL4 projects on Ubuntu include instal
 sudo apt-get install cmake ccache ninja-build
 sudo apt-get install python-dev python-pip python3-dev python3-pip
 sudo apt-get install libxml2-utils ncurses-dev
-sudo apt-get install curl git doxygen dtc
+sudo apt-get install curl git doxygen device-tree-compiler
 ```
 
 To build for ARM targets you will need a cross compiler. In addition, to run seL4 projects on a simulator you will need `qemu`. Installation of these additional base dependencies include running:


### PR DESCRIPTION
ubuntu 18.04 has device-tree-compiler package not dtc