### PR TITLE
aenum and pyelftools python modules are required

### DIFF
--- a/Tutorials/index.md
+++ b/Tutorials/index.md
@@ -12,6 +12,13 @@ This page collates all available tutorials on seL4 material.
 
 *  [set up your machine](/GettingStarted#setting-up-your-machine).
 
+### Python Dependencies
+Additional python dependencies are required to build tutorials. To install you can run:
+```
+pip install --user aenum
+pip install --user pyelftools
+```
+
 ### Get the code
 ```
 mkdir sel4-tutorials-manifest


### PR DESCRIPTION
I believe aenum and pyelftools modules are also needed to build tutorials, I realized this when trying to build hello-world.