### PR TITLE
FAQ: Fix heading depth for correct TOC

### DIFF
--- a/FrequentlyAskedQuestions.md
+++ b/FrequentlyAskedQuestions.md
@@ -4,13 +4,13 @@ toc: true
 
 # Frequently Asked Questions on seL4
 
-# What is seL4?
+## What is seL4?
  seL4 is the most advanced member of the L4 microkernel
 family, notable for its comprehensive formal verification, which sets it
 apart from any other operating system. seL4 achieves this without
 compromising performance.
 
-## What is a microkernel?
+### What is a microkernel?
  A microkernel is the minimal core of an
 operating system (OS). It presents a very small subset of what is
 generally considered an operating system today. The definition of what
@@ -38,7 +38,7 @@ third-generation microkernels, such access rights are conferred by
 capabilities (unforgeable tokens representing privileges) and are fully
 delegatable.
 
-## What is the L4 microkernel family?
+### What is the L4 microkernel family?
  L4 is a family of very small,
 high-performance microkernels evolved from the first L4 microkernel
 developed by Jochen Liedtke in the early '90s. See the
@@ -52,7 +52,7 @@ inheritance. Node colours indicate author organisations. A full description of L
 this image source: "From L3 to seL4. What Have We Learnt in 20 Years of L4 Microkernels? [Elphinstone & Heiser, SOSP 2013]"</p>
 
 
-## How does seL4's performance compare to other microkernels?
+### How does seL4's performance compare to other microkernels?
  To the
 best of our knowledge, seL4 is the world's fastest microkernel on the
 supported processors, in terms of the usual ping-pong metric: the cost
@@ -71,7 +71,7 @@ fluctuate up and down by 5–10 cycles, but there is no longer a
 performance difference between verified and unverified branches on
 ARMv7. ARMv8 is not yet fully optimised.
 
-# What is the size of seL4?
+## What is the size of seL4?
 
 Obviously this depends on the processor architecture. 
 As an example, on the 64-bit RISC-V architecture, the single-core kernel compiles into about 138 KiB.
@@ -80,8 +80,8 @@ Meta-data for usermode processes, incl. address spaces (page tables), thread-con
 capability storage etc, will add to this. 
 (But note that in seL4's memory-management model, such dynamic memory must be supplied to the kernel by usermode code.)
 
-# On what hardware does seL4 run?
-## What processor architectures are supported?
+## On what hardware does seL4 run?
+### What processor architectures are supported?
 Presently seL4 runs on ARMv6 (ARM11), ARMv7 (Cortex A8,
 A9, A15) and x86 cores. Supported ARM platforms for these are the
 Freescale i.MX31, OMAP3 !BeagleBoard, Exynos Arndale 5250, Odroid-X,
@@ -90,7 +90,7 @@ x86 machines are supported.
 
 Talk to us if you have funds to support a port to further architectures.
 
-## What devices does seL4 support?
+### What devices does seL4 support?
  seL4, like any real microkernel,
 runs all device drivers in user mode, device support is therefore not
 the kernel's problem. The exceptions are a timer driver, which seL4
@@ -102,7 +102,7 @@ Other than that, device support is the user's problem. seL4 provides the
 mechanisms for user-mode device drivers, especially the ability to map
 device memory to drivers and forward IRQs as (asynchronous) messages.
 
-## What about DMA?
+### What about DMA?
  The formal verification of seL4 on the ARM
 platform assumes that the MMU has complete control over memory, which
 means the proof assumes that DMA is off. DMA devices can in theory
@@ -119,7 +119,7 @@ experimental branch. The VT-d extensions allow the kernel to restrict
 DMA and thereby enable DMA devices with untrusted user-level drivers.
 There is unverified support for the SystemMMU on multiple ARM boards.
 
-## Does seL4 support multicore?
+### Does seL4 support multicore?
  On x86, seL4 can be configured to
 support multiple CPUs. Current multicore support is through a
 multikernel configuration where each booted CPU is given a portion of
@@ -132,7 +132,7 @@ development; please refer to the
 [roadmap](https://sel4.systems/Info/Roadmap/) for anticipated
 release dates.
 
-## Can I run seL4 on an MMU-less microcontroller?
+### Can I run seL4 on an MMU-less microcontroller?
  Using seL4 without
 a full memory-management unit (MMU) makes little sense, as its resource
 management is fundamentally based on virtual memory. For lower-end
@@ -141,7 +141,7 @@ protection at all, you should look at NICTA's
 [eChronos real-time operating system](http://ts.data61.csiro.au/projects/TS/echronos/) (RTOS), which is designed for such
 processors and is also undergoing formal verification.
 
-## What are the intended applications of seL4?
+### What are the intended applications of seL4?
  seL4 is a
 general-purpose microkernel, so the answer is all of them. The main
 targets are embedded systems with security or reliability requirements,
@@ -151,8 +151,8 @@ areas that need isolation between different parts of the software.
 Immediate application areas are in the financial, medical, automotive,
 avionics and defence sectors.
 
-# How good is seL4 at supporting virtual machines?
-## Can I run Linux on top of seL4?
+## How good is seL4 at supporting virtual machines?
+### Can I run Linux on top of seL4?
 Yes, seL4 can run Linux in a virtual machine. At
 present the master branch supports this on ARMv7 processors (presently
 A15/A7 cores). For x86 there is experimental virtualisation support
@@ -165,7 +165,7 @@ Ring-0 root mode or ARM hyp mode) and forwards virtualisation events to
 a virtual machine monitor (VMM) which performs the necessary emulations.
 The VMM runs de-privileged (x86 Ring-3 root mode or ARM supv mode).
 
-## How does seL4+VMM compare with OKL4 or Codezero?
+### How does seL4+VMM compare with OKL4 or Codezero?
  That’s a bit
 difficult to answer, given that of the three, only seL4 is open-source.
 
@@ -177,11 +177,11 @@ The OKL4 Microvisor has a different API, especially designed to support
 efficient para-virtualisation. It has fairly mature userland, especially
 a driver framework.
 
-## Does seL4 support multiple virtual machines at once?
+### Does seL4 support multiple virtual machines at once?
  Yes, multiple
 VMs are supported, including heterogeneous ones.
 
-## Can I run a real-time OS in a virtual machine on seL4?
+### Can I run a real-time OS in a virtual machine on seL4?
  seL4 is the
 world’s only hypervisor with a sound worst-case execution-time (WCET)
 analysis, and as such the only one that can give you actual real-time
@@ -209,7 +209,7 @@ necessarily the way to go, although that somewhat depends on your
 circumstances. In general, you’ll better off running RT apps in a native
 seL4 environment.
 
-# What is formal verification?
+## What is formal verification?
  Formal software verification is the
 activity of using mathematical proof to show that a piece of software
 satisfies specific properties. Traditionally, formal verification has
@@ -230,7 +230,7 @@ prover is interactive, but offers a comparatively high degree of
 automation. It also offers a very high degree of assurance that the
 resulting proof is correct.
 
-## What does seL4's formal verification mean?
+### What does seL4's formal verification mean?
  Unique about seL4 is
 its unprecedented degree of assurance, achieved through formal
 verification. Specifically, the ARM, ARM\_HYP (ARM with virtualisation
@@ -262,7 +262,7 @@ latencies of any other kernel operations). It is therefore the only
 kernel with memory protection that can give you hard real-time
 guarantees.
 
-## Does seL4 have zero bugs?
+### Does seL4 have zero bugs?
  The functional correctness proof states
 that, if the proof assumptions are met, the seL4 kernel implementation
 has no deviations from its specification. The security proofs state that
@@ -286,7 +286,7 @@ systems, this is not a problem, because analysing hardware and proof
 assumptions is much easier than analysing a large software system, the
 same hardware, and test assumptions.
 
-## Is seL4 proved secure?
+### Is seL4 proved secure?
  This depends on what you mean by secure. In
 the interpretation of classic operating system security, the answer is
 yes. In particular, seL4 has been proved to enforce specific security
@@ -300,7 +300,7 @@ formally verified by the user. While these restrictions are common for
 high-assurance systems, we are working to reduce them, for instance
 through the use of IOMMUs on x86 or System MMUs on ARM.
 
-## If I run seL4, is my system secure?
+### If I run seL4, is my system secure?
  Not automatically, no.
 Security is a question that spans the whole system, including its human
 parts. An OS kernel, verified or not, does not automatically make a
@@ -311,7 +311,7 @@ However, if used correctly, seL4 provides the system architect and user
 with strong mechanisms to implement security policies, backed by
 specific security theorems.
 
-## What are the proof assumptions?
+### What are the proof assumptions?
  The brief version is: we assume
 that in-kernel assembly code is correct, hardware behaves correctly,
 in-kernel hardware management (TLB and caches) is correct, and boot code
@@ -323,7 +323,7 @@ For a more in-depth description, see the
 [proof and assumptions
 page](http://sel4.systems/Info/FAQ/proof.pml).
 
-## How do I leverage seL4's formal proofs?
+### How do I leverage seL4's formal proofs?
  The seL4 proofs are just
 the first step in building secure systems. They provide the tools that
 application and system developers need for providing evidence that their
@@ -340,7 +340,7 @@ of the entire system.
 If you are interested in connecting to the seL4 proofs, let us know, as we
 may be able to offer assistance.
 
-## Have OS kernels not been verified before?
+### Have OS kernels not been verified before?
  OS verification goes
 back at least 40 years to the mid 1970s, so there is plenty of previous
 work on verified OS kernels. See also a
@@ -365,7 +365,7 @@ been achieved. It is only in the last 5-10 years that code verification
 and theorem proving technology has advanced enough to make large
 code-level proofs feasible.
 
-## When and how often does seL4 get updated and re-proved?
+### When and how often does seL4 get updated and re-proved?
  We update
 the seL4 proofs semi-continuously, usually whenever something is pulled
 into the master branch in the seL4 GitHub repository. You can see the
@@ -389,7 +389,7 @@ happen per year unless there is specific funding for a specific feature.
 Small updates take a day to a few weeks and we often do them on the
 side. There's no specific schedule at the moment.
 
-## How do I tell which code in GitHub is covered by the proof and which isn't?
+### How do I tell which code in GitHub is covered by the proof and which isn't?
  The verification sees the entire C code for one particular
 combination of configuration options. See [Verified
 Configurations](/VerifiedConfigurations) for details of architecture and
@@ -436,7 +436,7 @@ As an example, the CPU and architecture options mean that everything
 under src/arch/ia32 is not covered by the proof, but that the files in
 src/kernel/object are.
 
-# How are resources managed and protected in seL4?
+## How are resources managed and protected in seL4?
 
 
 The key idea in seL4 is that all resource management is done in
@@ -447,7 +447,7 @@ management itself. It has no heap, just a few global variables, a
 strictly bounded stack, and memory explicitly provided to it by
 userland.
 
-## What are capabilities?
+### What are capabilities?
 
 
 Capabilities are an OS abstraction for managing access rights. A
@@ -469,7 +469,7 @@ references.
 See the wikipedia article on
 [capability-based security](https://en.wikipedia.org/wiki/Capability-based_security) for more details on caps.
 
-## How can usermode manage kernel memory safely?
+### How can usermode manage kernel memory safely?
 
 
 The kernel puts userland in control of system resources by handing all
@@ -493,7 +493,7 @@ These can be mapped into an ''Address Space Object'' (essentially a page
 table), after which userland can write to the physical memory
 represented by the Frame Objects.
 
-## How can threads communicate?
+### How can threads communicate?
 
 
 Communication can happen via message-passing IPC or shared memory. IPC
@@ -512,7 +512,7 @@ sender's to the receiver's address space.
 
 Shared-buffer access can be synchronised via ''Notifications''.
 
-## How does message-passing work?
+### How does message-passing work?
 
 
 As is characteristic to members of the L4 microkernel family, seL4 uses
@@ -533,7 +533,7 @@ trying to receive from the Endpoint.
 Message broadcast is a higher-level abstraction that can be implemented
 on top of seL4's primitive mechanisms.
 
-## Why do send-only operations not return a success indication?
+### Why do send-only operations not return a success indication?
 
 
 The send-only IPC system calls ''seL4_Send()'' and ''seL4_NBSend()''
@@ -547,7 +547,7 @@ flow that is not explicitly authorised by a capability.
 
 In short, it's a feature, not a bug (painful as it may be).
 
-## What are Notifications?
+### What are Notifications?
 
 
 A ''Notification Object'' is logically a small array of binary
@@ -566,7 +566,7 @@ Notifications can also be ''Polled'', which is like Wait, except the
 operation does not block, and instead returns zero immediately, even if
 the Notification bit string is zero.
 
-## What is the seL4 fastpath?
+### What is the seL4 fastpath?
 
 
 The fastpath is an add-on frontend to the kernel which performs the
@@ -580,32 +580,32 @@ kernel behaviour except for performance.
 There is a section on the fastpath and its verification in
 [this article](http://ts.data61.csiro.au/publications/nictaabstracts/Klein_AEMSKH_14.abstract.pml). The fastpath discussion starts on page 23.
 
-## I want to know more about seL4 functionality/design/implementation/philosophy
+### I want to know more about seL4 functionality/design/implementation/philosophy
 
 
 There are plenty of references on the [documentation page](/Documentation).
 
-# What can I do with seL4?
+## What can I do with seL4?
  You can use seL4 for research, education or
 commerce. Details are specified in the standard open-source
 [licenses](#what-are-the-licensing-conditions) that come with the code. Different licenses apply
 to different parts of the code, but the conditions are designed to ease
 uptake.
 
-# What are the licensing conditions?
+## What are the licensing conditions?
 
 The seL4 kernel is released under GPL Version 2. Userland tools and
 libraries are mostly under BSD. See the
 [license page](http://sel4.systems/Info/GettingStarted/license.pml) for more details.
 
-# How do I contribute to seL4?
+## How do I contribute to seL4?
  See
 [How to Contribute](Contributing.md). In brief, seL4 was released under a complicated
 agreement between the partners who owned the code. A condition of the
 release is that we track all contributions, and get a signed licence
 agreement from all contributors.
 
-# How can I build a system with seL4?
+## How can I build a system with seL4?
  Much more is required to build a
 system on seL4 compared to building on, say Linux. Having decomposed
 your system into modules, you will need to work out what access each
@@ -630,7 +630,7 @@ builds an OS on top of seL4. If you have access to an [Odroid-C2](https://www.ha
 you should be able to do the project work yourself as a way of
 familiarising yourself with seL4.
 
-# Where can I learn more?
+## Where can I learn more?
 CSIRO's
 [seL4 project](http://ts.data61.csiro.au/projects/seL4/) and
 [Trustworthy Systems](http://ts.data61.csiro.au/)
@@ -648,7 +648,7 @@ all peer-reviewed publications. Good starting points are:
       of the cost of verification, and how it compares to that of
       traditionally-engineered systems.
 
-# What's coming up next?
+## What's coming up next?
  We're currently working on a number of
 things. As we're in a research environment (not a product development
 environment) we cannot commit to dates, or the order in which any of


### PR DESCRIPTION
Add 1 to the depth of each heading for the FrequentlyAskedQuestions
page except the page title heading.
The table of contents generation assumes all headings on the page start
from depth 2 and the page title is the only heading with depth 1.