### PR TITLE
Remove support for KZM platform from documentation

### DIFF
--- a/Hardware/Kzm.md
+++ b/Hardware/Kzm.md
@@ -1,5 +1,4 @@
 ---
-arm_hardware: true
 simulation_target: true
 cmake_plat: kzm
 xcompiler_arg: -DAARCH32=1
@@ -15,15 +14,10 @@ Maintained: Data61
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
-# KZM
+# KZM (Deprecated seL4 platform)
 
-seL4 supports the the
-KZM-ARM11-01, which can
-also be simulated in qemu.
+**seL4 previously supported the KZM-ARM11-01 unitl version 12.1.0, which can also be simulated in qemu.**
+**Support for this platform has since been removed**
 
 The KZM is deprecated, ARMv11 Hardware which was used for the original seL4 verification. The latest
 verification platform is the [SabreLite](/Hardware/sabreLite).
-
-## Simulation
-
-{% include sel4test.md %}

--- a/_data/projects/sel4.yml
+++ b/_data/projects/sel4.yml
@@ -515,14 +515,6 @@ configurations:
     maintainer: "Data61"
     status: "x86 Option. (Default: OFF)"
     component_type: platform-x86
-  - name: KernelDangerousCodeInjectionOnUndefInstr
-    display_name: "KernelDangerousCodeInjectionOnUndefInstr"
-    description: "Replaces the undefined instruction handler with a call to a function pointer in r8.
-    This is an alternative mechanism to the code injection syscall. This option is mainly used
-    for benchmarking the kernel on ARMv6 platforms and has no effect on non-ARMv6 platforms."
-    maintainer: "Data61"
-    status: "Arm option. (Default: OFF)"
-    component_type: platform-arm
   - name: KernelDebugDisableL2Cache
     display_name: "KernelDebugDisableL2Cache"
     description: "Do not enable the L2 cache on startup for debugging purposes."
@@ -834,12 +826,6 @@ components:
     maintainer: "Data61"
     status: "active, currently used by the hifive seL4 platform"
     component_type: kernel-driver-irq
-  - name: fsl,imx31-avic
-    display_name: "fsl,imx31-avic"
-    description: "i.MX31 interrupt controller seL4 driver"
-    maintainer: "Data61"
-    status: "active, currently used by the kzm seL4 platform"
-    component_type: kernel-driver-irq
   - name: ti,omap3-intc
     display_name: "ti,omap3-intc"
     description: "omap3 interrupt controller seL4 driver"
@@ -960,12 +946,6 @@ components:
     maintainer: "Data61"
     status: "Active, currently used by the exynos4 seL4 platform"
     component_type: kernel-driver-timer
-  - name: fsl,imx31-epit
-    display_name: "fsl,imx31-epit"
-    description: "i.MX31 EPIT timer seL4 driver"
-    maintainer: "Data61"
-    status: "Active, currently used by the kzm seL4 platform"
-    component_type: kernel-driver-timer
   - name: ti,omap3430-timer
     display_name: "ti,omap3430-timer"
     description: "omap3 timer seL4 driver"
@@ -977,12 +957,6 @@ components:
     description: "Arm generic timer seL4 driver"
     maintainer: "Data61"
     status: "Active, currently used by several Arm seL4 platforms"
-    component_type: kernel-driver-timer
-  - name: "fsl,imx31-gpt"
-    display_name: "fsl,imx31-gpt"
-    description: "i.MX31 GPT timer seL4 driver"
-    maintainer: "Data61"
-    status: "Active, currently used by the kzm seL4 platform"
     component_type: kernel-driver-timer
   - name: "arm,cortex-a9-twd-timer"
     display_name: "arm,cortex-a9-twd-timer"
@@ -1054,12 +1028,6 @@ components:
   - name: exynos5422.dts
     display_name: exynos5422.dts
     description: "exynos5422 platform device tree (dts) sourced from Linux kernel path: exynos5422-odroidxu4"
-    maintainer: "Data61"
-    status: "active"
-    component_type: kernel-device-tree
-  - name: kzm.dts
-    display_name: kzm.dts
-    description: "kzm platform device tree (dts) sourced from Linux kernel path: imx31-bug"
     maintainer: "Data61"
     status: "active"
     component_type: kernel-device-tree


### PR DESCRIPTION
This updates the Hardware/Kzm page to describe the KZM as a previously
supported platform and what the last supported version was. Also removes
the KZM from the list of hardware platforms on the Hardware page and
removes the KZM related drivers and config options from the seL4 project
status page.

Signed-off-by: Kent McLeod <kent@kry10.com>