### PR TITLE
microkit: use tables for SDK downloads

### DIFF
--- a/_data/projects/microkit.yml
+++ b/_data/projects/microkit.yml
@@ -16,43 +16,77 @@ sdk_downloads:
     sdks:
     - label: "microkit-sdk-2.0.1-linux-x86-64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/2.0.1/microkit-sdk-2.0.1-linux-x86-64.tar.gz"
+      os: Linux
+      arch: x86-64
     - label: "microkit-sdk-2.0.1-linux-aarch64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/2.0.1/microkit-sdk-2.0.1-linux-aarch64.tar.gz"
+      os: Linux
+      arch: AArch64
     - label: "microkit-sdk-2.0.1-macos-x86-64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/2.0.1/microkit-sdk-2.0.1-macos-x86-64.tar.gz"
+      os: macOS
+      arch: x86-64
     - label: "microkit-sdk-2.0.1-macos-aarch64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/2.0.1/microkit-sdk-2.0.1-macos-aarch64.tar.gz"
+      os: macOS
+      arch: AArch64
   - version: 2.0.0
     sdks:
     - label: "microkit-sdk-2.0.0-linux-x86-64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/2.0.0/microkit-sdk-2.0.0-linux-x86-64.tar.gz"
+      os: Linux
+      arch: x86-64
     - label: "microkit-sdk-2.0.0-linux-aarch64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/2.0.0/microkit-sdk-2.0.0-linux-aarch64.tar.gz"
+      os: Linux
+      arch: AArch64
     - label: "microkit-sdk-2.0.0-macos-x86-64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/2.0.0/microkit-sdk-2.0.0-macos-x86-64.tar.gz"
+      os: macOS
+      arch: x86-64
     - label: "microkit-sdk-2.0.0-macos-aarch64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/2.0.0/microkit-sdk-2.0.0-macos-aarch64.tar.gz"
+      os: macOS
+      arch: AArch64
   - version: 1.4.1
     sdks:
     - label: "microkit-sdk-1.4.1-linux-x86-64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/1.4.1/microkit-sdk-1.4.1-linux-x86-64.tar.gz"
+      os: Linux
+      arch: x86-64
     - label: "microkit-sdk-1.4.1-macos-x86-64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/1.4.1/microkit-sdk-1.4.1-macos-x86-64.tar.gz"
+      os: macOS
+      arch: x86-64
     - label: "microkit-sdk-1.4.1-macos-aarch64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/1.4.1/microkit-sdk-1.4.1-macos-aarch64.tar.gz"
+      os: macOS
+      arch: AArch64
   - version: 1.4.0
     sdks:
     - label: "microkit-sdk-1.4.0-linux-x86-64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/1.4.0/microkit-sdk-1.4.0-linux-x86-64.tar.gz"
+      os: Linux
+      arch: x86-64
     - label: "microkit-sdk-1.4.0-macos-x86-64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/1.4.0/microkit-sdk-1.4.0-macos-x86-64.tar.gz"
+      os: macOS
+      arch: x86-64
     - label: "microkit-sdk-1.4.0-macos-aarch64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/1.4.0/microkit-sdk-1.4.0-macos-aarch64.tar.gz"
+      os: macOS
+      arch: AArch64
   - version: 1.3.0
     sdks:
     - label: "microkit-sdk-1.3.0-linux-x86-64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/1.3.0/microkit-sdk-1.3.0-linux-x86-64.tar.gz"
+      os: Linux
+      arch: x86-64
     - label: "microkit-sdk-1.3.0-macos-x86-64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/1.3.0/microkit-sdk-1.3.0-macos-x86-64.tar.gz"
+      os: macOS
+      arch: x86-64
     - label: "microkit-sdk-1.3.0-macos-aarch64.tar.gz"
       url: "https://github.com/seL4/microkit/releases/download/1.3.0/microkit-sdk-1.3.0-macos-aarch64.tar.gz"
+      os: macOS
+      arch: aarch64

--- a/projects/microkit/releases.md
+++ b/projects/microkit/releases.md
@@ -26,11 +26,31 @@ Because of this we need to split the list into two before sorting.
 
 {% for release in releases reversed -%}
 
-- Microkit Release [{{ release.title }}]({{ release.url | relative_url }}) {% if forloop.first %}(latest){% endif %}
+## {{ release.title }} {% if forloop.first %}(latest){% endif %}
+
+[Release notes]({{ release.url | relative_url }})
+
+<table>
+  <thead>
+    <tr>
+      <th scope="col">OS</th>
+      <th scope="col">Arch</th>
+      <th scope="col">Download</th>
+      <th scope="col">Signature</th>
+    </tr>
+  </thead>
+  <tbody>
 {%- assign sdks = sdk_downloads | where: "version", release.title %}
 {%- assign sdks = sdks[0] %}
 {%-  for sdk in sdks.sdks %}
-  - [{{ sdk.label }}]({{sdk.url}}) [[sig]({{sdk.url}}.asc)]
+    <tr>
+      <th scope="row">{{ sdk.os }}</th>
+      <th scope="row">{{ sdk.arch }}</th>
+      <th scope="row"><a href="{{ sdk.url }}">{{ sdk.label }}</a></th>
+      <th scope="row"><a href="{{ sdk.url }}.asc">sig</a></th>
+    </tr>
 {%-   endfor %}
+  </tbody>
+</table>
 
 {% endfor %}


### PR DESCRIPTION
I think this makes it a bit easier to see which SDK download you want to use. Will help if/when we add more SDK host targets as well.

I initially tried to do this with a Markdown table but could not get it working when it is within the templating for loop, I don't know if it's supposed to work or an error on my part.

For now I've made it an HTML table but I can change that if Markdown is supposed to work.