### PR TITLE
microkit: add SDK link to release notes

### DIFF
--- a/content_collections/_releases/microkit/2.1.0.md
+++ b/content_collections/_releases/microkit/2.1.0.md
@@ -14,6 +14,8 @@ This release contains various bug fixes, quality-of-life changes, features, and 
 
 There are no breaking changes.
 
+You can find the SDK downloads [here](../microkit).
+
 ## Feature changes
 
 * Initial x86-64 support.


### PR DESCRIPTION
Most of the links we use to point people to the release are the page that contains the release notes, but that doesn't tell you where to get the SDKs so this is important.