### PR TITLE
hardware: Fix platform for compiling X64 and IA32

### DIFF
--- a/Hardware/IA32.md
+++ b/Hardware/IA32.md
@@ -1,5 +1,5 @@
 ---
-cmake_plat: ia32
+cmake_plat: pc99
 simulation_target: true
 simulation_only: false
 arch: x86

--- a/Hardware/X64.md
+++ b/Hardware/X64.md
@@ -1,5 +1,5 @@
 ---
-cmake_plat: x64
+cmake_plat: pc99
 simulation_target: true
 simulation_only: false
 arch: x64


### PR DESCRIPTION
Wrong `cmake_plat` was specified resulting in creation of a wrong command for sel4test builds.