### PR TITLE
X64: fix wrong cmake platform name

### DIFF
--- a/Hardware/X64.md
+++ b/Hardware/X64.md
@@ -1,5 +1,5 @@
 ---
-cmake_plat: x64
+cmake_plat: x86_64
 simulation_target: true
 simulation_only: false
 arch: x64


### PR DESCRIPTION
Just `x64` does not actually work..