### PR TITLE
microkit: fix manual diagram file

### DIFF
--- a/projects/microkit/manual/2.1.0/index.md
+++ b/projects/microkit/manual/2.1.0/index.md
@@ -1663,7 +1663,7 @@ and all the components of Microkit. As a user of Microkit, it is not necessary
 know this information, however, there is no harm in having a greater
 understanding of the tools that you are using.
 
-![Microkit flow](assets/microkit_flow.pdf)
+![Microkit flow](assets/microkit_flow.svg)
 
 The diagram above aims to show the general flow of a Microkit system from
 build-time to run-time.


### PR DESCRIPTION
Need to use SVG instead of PDF since inline PDF only works in some browsers (e.g it does not work in Firefox).

Fix quickly for now, automate this process for future Microkit releases.

Closes https://github.com/seL4/docs/issues/321.