### PR TITLE
trivial: fix two ltimer component types

### DIFF
--- a/_data/projects/user_libs.yml
+++ b/_data/projects/user_libs.yml
@@ -686,7 +686,7 @@ components:
     description: "ltimer implementation for the OMAP platforms using GPT timers"
     maintainer: "seL4 Foundation"
     status: "Supported on OMAP SoCs"
-    component_type: user-driver-other
+    component_type: user-driver-ltimer
   - name: mach/imx/epit/epit.c
     display_name: "mach/imx/epit/epit.c"
     description: "EPIT driver for the EPIT timers in the i.MX SoCs"
@@ -776,7 +776,7 @@ components:
     description: "ltimer implementation for the Exynos platforms using the PWM timers"
     maintainer: "seL4 Foundation"
     status: "Supported on the Exynos SoCs"
-    component_type: user-driver-pinmux
+    component_type: user-driver-ltimer
   - name: mach/exynos/spi.c
     display_name: "mach/exynos/spi.c"
     description: "SPI driver for the SPI devices in the Exynos SoCs"


### PR DESCRIPTION
Their names reads like ltimer types?