### PR TITLE
microkit: update roadmap/platforms

### DIFF
--- a/projects/microkit/platforms.md
+++ b/projects/microkit/platforms.md
@@ -8,8 +8,8 @@ SPDX-FileCopyrightText: 2025 Proofcraft Pty Ltd
 The following platforms are supported by the seL4 Microkit. See also the section
 on [Board Support Packages](manual/latest/#bsps) in the Microkit manual.
 
-Microkit currently supports [Arm](#arm) AArch64 and [RISC-V](#risc-v) boards. x64
-support is on the [roadmap](roadmap.html).
+Microkit currently supports x86-64, [Arm](#arm) and [RISC-V](#risc-v) platforms.
+Only 64-bit platforms are supported currently.
 
 {%- assign platforms = site.data.microkit_platforms.platforms %}
 

--- a/projects/microkit/roadmap.md
+++ b/projects/microkit/roadmap.md
@@ -17,17 +17,10 @@ or [contact the developers](https://sel4.systems/support.html).
 
 | Feature | Current status | Timeline | Availability |
 |-----------------------------------------------------------|
-| Multi-core support | Merged, available in 2.1.0 | Q4'25 | [PR #353](https://github.com/seL4/microkit/pull/353) |
-| [x86 support](#x86) | Merged, available in 2.1.0 | Q4'25 | [PR #337](https://github.com/seL4/microkit/pull/337) |
-| [Multi-kernel support](#multikernel) | Actively worked on. | Q4'25 | [Branch](https://github.com/au-ts/multikernel-manifest/) |
-| [PD templates](#templates) | Initial work explored, requires more experimentation and development. | Q1'26 | N/A |
+| [Multi-kernel support](#multikernel) | Actively worked on. | N/A | [Manifest](https://github.com/au-ts/multikernel-manifest/) |
+| [PD templates](#templates) | Initial work explored, requires more experimentation and development. | N/A | N/A |
 
 ## Feature details
-
-### x86 support {#x86}
-
-x86-64 support is available in the latest Microkit (since [PR #337](https://github.com/seL4/microkit/pull/337)),
-but not in an available release. The next release will contain x86-64 support.
 
 ### Multi-kernel support {#multikernel}
 


### PR DESCRIPTION
The platforms page doesn't consider x86 right now so it looks a bit weird, I will fix in a follow up.