### PR TITLE
github: bump GH action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     name: Site
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         submodules: true
@@ -34,7 +34,7 @@ jobs:
     - run: sudo apt-get install doxygen
     - run: make build JEKYLL_ENV=production
     - run: tar -cvf site.tar _site/
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: site
         path: site.tar
@@ -47,13 +47,13 @@ jobs:
     name: 'Deploy'
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: gh-pages
         token: ${{ secrets.GH_TOKEN }}
     # for removing files, we need to start fresh; this does not remove dot-files
     - run: rm -rf *
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: site
     - run: tar -xvf site.tar


### PR DESCRIPTION
Node 20 is deprecated. Bump GitHub action dependencies to versions that run on more recent node.