### PR TITLE
_includes: update RISC-V toolchain build

### DIFF
--- a/_includes/risc-v.md
+++ b/_includes/risc-v.md
@@ -8,7 +8,6 @@ It is recommended to build the toolchain from source.
 ```sh
 git clone https://github.com/riscv/riscv-gnu-toolchain.git
 cd riscv-gnu-toolchain
-git submodule update --init --recursive
 export RISCV=/opt/riscv
 ./configure --prefix="${RISCV}" --enable-multilib
 make linux


### PR DESCRIPTION
The RISC-V toolchain no longer needs a separate submodule init. (Now part of its build system.)